### PR TITLE
add webathena setup link to warning banner

### DIFF
--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -177,8 +177,8 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
             <strong>Your Zephyr mirror is not working.</strong>
             <span id="normal-zephyr-mirror-error-text">
                 We recommend that
-                you <a href="#webathena" class="webathena_login">give Zulip the ability to mirror the messages for you via
-            Webathena</a>.  If you'd prefer, you can instead
+                you give Zulip the ability to mirror the messages for you via
+                Webathena (in the gear icon menu). If you'd prefer, you can instead
                 <a href="/zephyr-mirror/" target="_blank" rel="noopener noreferrer">run the
             Zephyr mirror script yourself</a> in a screen
             session.

--- a/templates/zerver/app/index.html
+++ b/templates/zerver/app/index.html
@@ -177,7 +177,7 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1943053 -->
             <strong>Your Zephyr mirror is not working.</strong>
             <span id="normal-zephyr-mirror-error-text">
                 We recommend that
-                you <a class="webathena_login">give Zulip the ability to mirror the messages for you via
+                you <a href="#webathena" class="webathena_login">give Zulip the ability to mirror the messages for you via
             Webathena</a>.  If you'd prefer, you can instead
                 <a href="/zephyr-mirror/" target="_blank" rel="noopener noreferrer">run the
             Zephyr mirror script yourself</a> in a screen


### PR DESCRIPTION
<!-- Describe your pull request here.-->

~Fixes: warning to set up zephyr didn't work when clicked because it was missing an href.~

~I added the same one as [in the settings menu](https://github.com/sipb-zephyr-zulip/zulip/blob/caf9590804972f935d0a2b91177dd4ae73a139ae/web/templates/popovers/navbar/navbar_gear_menu_popover.hbs#L198), which did work for me just last week.
It has the same class already so everything _should_ be the same now.~

Fixes: warning to set up zephyr didn't work when clicked -- this tells people the working flow (via the gear menu)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:** (none)

<details>
<summary>Self-review checklist</summary>

I didn't test this at all. It seemed trivial enough to not bother figuring out how to build the codebase etc. Sorry :)

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [x] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [x] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [x] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
